### PR TITLE
Add patches to enable compilation with r_clang

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ Home: https://github.com/r-lib/cpp11
 
 Package license: MIT
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/r-cpp11-feedstock/blob/master/LICENSE.txt)
 
 Summary: Provides a header only, C++11 interface to R's C interface. Compared to other approaches 'cpp11' strives to be safe against long jumps from the C API as well as C++ exceptions, conform to normal R function semantics and supports interaction with 'ALTREP' vectors.
-
-
 
 Current build status
 ====================

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specifiy the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/0001-Mark-r_vector-const_iterator-operator-as-const.patch
+++ b/recipe/0001-Mark-r_vector-const_iterator-operator-as-const.patch
@@ -1,0 +1,81 @@
+From e2e5993c6e0a85f42e81e92d26dc5cd88e7c501f Mon Sep 17 00:00:00 2001
+From: "Uwe L. Korn" <uwe.korn@quantco.com>
+Date: Fri, 9 Oct 2020 14:23:04 +0200
+Subject: [PATCH 1/3] Mark r_vector::const_iterator::operator* as const
+
+Fixes #113
+---
+ inst/include/cpp11/list.hpp     | 2 +-
+ inst/include/cpp11/r_vector.hpp | 8 ++++----
+ inst/include/cpp11/strings.hpp  | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/inst/include/cpp11/list.hpp b/inst/include/cpp11/list.hpp
+index 43c6fc2..c848db9 100644
+--- a/inst/include/cpp11/list.hpp
++++ b/inst/include/cpp11/list.hpp
+@@ -52,7 +52,7 @@ inline void r_vector<SEXP>::const_iterator::fill_buf(R_xlen_t) {
+ }
+ 
+ template <>
+-inline SEXP r_vector<SEXP>::const_iterator::operator*() {
++inline SEXP r_vector<SEXP>::const_iterator::operator*() const {
+   return VECTOR_ELT(data_->data(), pos_);
+ }
+ 
+diff --git a/inst/include/cpp11/r_vector.hpp b/inst/include/cpp11/r_vector.hpp
+index dc696c1..1d0eb49 100644
+--- a/inst/include/cpp11/r_vector.hpp
++++ b/inst/include/cpp11/r_vector.hpp
+@@ -155,7 +155,7 @@ class r_vector {
+     inline bool operator!=(const const_iterator& other) const;
+     inline bool operator==(const const_iterator& other) const;
+ 
+-    inline T operator*();
++    inline T operator*() const;
+ 
+     friend class writable::r_vector<T>::iterator;
+ 
+@@ -265,7 +265,7 @@ class r_vector : public cpp11::r_vector<T> {
+ 
+     inline iterator& operator++();
+ 
+-    inline proxy operator*();
++    inline proxy operator*() const;
+ 
+     using cpp11::r_vector<T>::const_iterator::operator!=;
+ 
+@@ -554,7 +554,7 @@ inline typename cpp11::r_vector<T>::const_iterator cpp11::r_vector<T>::find(
+ }
+ 
+ template <typename T>
+-inline T r_vector<T>::const_iterator::operator*() {
++inline T r_vector<T>::const_iterator::operator*() const {
+   if (data_->is_altrep()) {
+     return buf_[pos_ - block_start_];
+   } else {
+@@ -586,7 +586,7 @@ r_vector<T>::proxy::proxy(SEXP data, const R_xlen_t index, T* const p, bool is_a
+     : data_(data), index_(index), p_(p), is_altrep_(is_altrep) {}
+ 
+ template <typename T>
+-inline typename r_vector<T>::proxy r_vector<T>::iterator::operator*() {
++inline typename r_vector<T>::proxy r_vector<T>::iterator::operator*() const {
+   if (data_.is_altrep()) {
+     return proxy(data_.data(), pos_, &buf_[pos_ - block_start_], true);
+   } else {
+diff --git a/inst/include/cpp11/strings.hpp b/inst/include/cpp11/strings.hpp
+index 311abe9..bf5b1b2 100644
+--- a/inst/include/cpp11/strings.hpp
++++ b/inst/include/cpp11/strings.hpp
+@@ -41,7 +41,7 @@ inline void r_vector<r_string>::const_iterator::fill_buf(R_xlen_t) {
+ }
+ 
+ template <>
+-inline r_string r_vector<r_string>::const_iterator::operator*() {
++inline r_string r_vector<r_string>::const_iterator::operator*() const {
+   return STRING_ELT(data_->data(), pos_);
+ }
+ 
+-- 
+2.28.0
+

--- a/recipe/0002-Add-const-cast-to-fix-compilation.patch
+++ b/recipe/0002-Add-const-cast-to-fix-compilation.patch
@@ -1,0 +1,25 @@
+From 5db90f3eea98291793289d1c1937b6cef87092df Mon Sep 17 00:00:00 2001
+From: Jim Hester <james.f.hester@gmail.com>
+Date: Fri, 9 Oct 2020 10:58:07 -0400
+Subject: [PATCH 2/3] Add const cast to fix compilation
+
+---
+ inst/include/cpp11/r_vector.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/inst/include/cpp11/r_vector.hpp b/inst/include/cpp11/r_vector.hpp
+index 1d0eb49..2a57a9d 100644
+--- a/inst/include/cpp11/r_vector.hpp
++++ b/inst/include/cpp11/r_vector.hpp
+@@ -588,7 +588,7 @@ r_vector<T>::proxy::proxy(SEXP data, const R_xlen_t index, T* const p, bool is_a
+ template <typename T>
+ inline typename r_vector<T>::proxy r_vector<T>::iterator::operator*() const {
+   if (data_.is_altrep()) {
+-    return proxy(data_.data(), pos_, &buf_[pos_ - block_start_], true);
++    return proxy(data_.data(), pos_, const_cast<T*>(&buf_[pos_ - block_start_]), true);
+   } else {
+     return proxy(data_.data(), pos_,
+                  data_.data_p_ != nullptr ? &data_.data_p_[pos_] : nullptr, false);
+-- 
+2.28.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,15 @@ source:
     - {{ cran_mirror }}/src/contrib/cpp11_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/cpp11/cpp11_{{ version }}.tar.gz
   sha256: 88a08a99891d69a7ee199364314c6556f955d1368d1f4f9d252df741e53c30ac
+  patches:
+    # Needed to use packages with compiler('r_clang') on Windows
+    # Can be removed with the next version
+    - 0001-Mark-r_vector-const_iterator-operator-as-const.patch
+    - 0002-Add-const-cast-to-fix-compilation.patch
 
 build:
   merge_build_host: true  # [win]
-  number: 0
+  number: 1
   noarch: generic
   rpaths:
     - lib/R/lib/


### PR DESCRIPTION
Needed for `r-arrow 2.0`
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
